### PR TITLE
fix: #5 Improve CSS layout for panels

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,21 +8,14 @@ body {
 }
 
 #app {
-    /* height: 100vh; */
+     height: 100vh;
 }
 
 #te-toplevel {
-    display: grid;
+    display: flex;
+    flex-direction: column;
     gap: 1px;
-    grid-template-areas: 
-        "header"
-        "te-tabs-header"
-        "te-tabs-container"
-        "footer"
-        ;
-    /* grid-template-columns: minmax(auto, 12em) 1fr; */
-    grid-template-rows: auto auto minmax(10px, 1fr) auto;
-    height: 100vh;
+    height: 100%;
 }
 
 #te-header {
@@ -31,28 +24,28 @@ body {
 
 /* -------- tabs ------------- */
 .te-tabs-container {
+    flex: 1;
     grid-area: te-tabs-container;
     border-left: 1px solid lightgray;
+    overflow: auto;
     /* background-color: yellowgreen; */
     /* padding: 5px; */
     /* border: 1px solid black; */
 }
 
 .tab-content {
+    height: 100%;
     /* border: 1px solid red; */
     /* background-color: lightcoral; */
 }
 
 #te-tabs-header {
-    grid-area: te-tabs-header;
 }
 
 
 
 #te-footer {
-    grid-area: footer;
     background: rgb(248, 249, 250);
-    z-index: 10;
 }
 
 
@@ -64,7 +57,7 @@ body {
 }
 
 .symbol-information pre {
-    margin: 0px;
+    margin: 0;
     font-size: xx-small;
 }
 
@@ -74,7 +67,7 @@ body {
 }
 
 .occurrence pre {
-    margin: 0px;
+    margin: 0;
     font-size: xx-small;
 }
 
@@ -84,7 +77,7 @@ body {
 }
 
 .synthetic pre {
-    margin: 0px;
+    margin: 0;
     font-size: xx-small;
 }
 
@@ -94,13 +87,14 @@ body {
     display: grid;
     /* grid-template-columns: minmax(100px, 1fr) minmax(min-content, 2fr); */
     grid-template-columns: 2fr 1fr;
+    height: 100%
 }
 
 .semanticdb-document-container {
     /* padding: 10px; */
     /* border: 1px solid black; */
     /* background-color: rgb(91, 109, 251); */
-    max-height: 90vh;
+    height: 100%;
     overflow: auto;
 }
 /* 
@@ -117,7 +111,7 @@ body {
 
 
 .structure {
-    max-height: 90vh;
+    height: 100%;
     overflow: auto;
 }
 
@@ -128,6 +122,7 @@ body {
 }
 
 #semanticdb-tab-pane {
+    height: 100%;
     /* background-color: rgb(173, 120, 223); */
     /* border: 1px solid blueviolet; */
     /* margin: 5px; */

--- a/ui/src/main/scala/app/components/tabs/SemanticDB.scala
+++ b/ui/src/main/scala/app/components/tabs/SemanticDB.scala
@@ -16,13 +16,17 @@ import com.raquo.airstream.core.Signal
 def semanticDBTab(documentsWithSource: EventStream[List[TextDocumentsWithSource]]) =
   div(
     cls := "text-document-areas",
-    ol(
+    div(
       cls := "structure",
-      children <-- documentsWithSource.split(_.semanticDbUri)(SemanticDB.structureLevel1),
+      ol(
+        children <-- documentsWithSource.split(_.semanticDbUri)(SemanticDB.structureLevel1),
+      )
     ),
-    ol(
+    div(
       cls := "semanticdb-document-container",
-      children <-- documentsWithSource.split(_.semanticDbUri)(SemanticDB.renderTextDocumentsWithSource)
+      ol(
+        children <-- documentsWithSource.split(_.semanticDbUri)(SemanticDB.renderTextDocumentsWithSource)
+      )
     )
   )
 


### PR DESCRIPTION
The idea is that the main container has the same size as the view port and does not scroll, instead each panel should scroll individually.

- Wraps structure and semanticdb-document-container ols in divs so they can have independent scroll bars
- Forces containers to have the same height as their parent, except the tab container which uses the space available after the header, tabs and footer are rendered